### PR TITLE
added "presentation mode" inhibitor for xfce

### DIFF
--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -228,3 +228,24 @@ class XautolockInhibitor(BaseInhibitor):
     @property
     def applicable(self):
         return os.system("pgrep xautolock") is 0
+    
+class xfceInhibitor(BaseInhibitor):
+
+    def __init__(self):
+        BaseInhibitor.__init__(self)
+
+    def inhibit(self):
+        self.running = True
+
+        os.system("xfconf-query -c xfce4-power-manager -p /xfce4-power-manager/presentation-mode -s true")
+
+    def uninhibit(self):
+        self.running = False
+
+        
+        os.system("xfconf-query -c xfce4-power-manager -p /xfce4-power-manager/presentation-mode -s false")
+
+    @property
+    def applicable(self):
+        # TODO!
+        return True


### PR DESCRIPTION
in xfce4-power-manager screen dimming is active even when PM is disabled but it has an allmighty mode  called "presentation mode" to prevent dimming and every other PM. 
added cli methods